### PR TITLE
Remove scroll listener when it is really not necessary

### DIFF
--- a/src/scrollindo.js
+++ b/src/scrollindo.js
@@ -28,6 +28,7 @@
     var elementOffsetTop = $element.offsetTop;
     if (windowScroll >= elementOffsetTop) {
       $element.classList.add(newClass);
+      window.removeEventListener('scroll', handleScroll);
     }
     setTimeout(allowScroll, 500);
   }


### PR DESCRIPTION
Just a simple performance improvement to avoid memory leak =)

cc. @afonsopacifer 